### PR TITLE
Refactor modal methods in ActivitiesTable to accept IDs

### DIFF
--- a/app/Livewire/Sys/Activities/ActivitiesTable.php
+++ b/app/Livewire/Sys/Activities/ActivitiesTable.php
@@ -144,8 +144,9 @@ class ActivitiesTable extends Component
      * @param Activity $activity
      * @return void
      */
-    public function openEditModal(Activity $activity): void
+    public function openEditModal($id): void
     {
+        $activity = Activity::find($id);
         $this->dispatch('open-modal', 'edit', $activity)->to('sys.activities.activity-form');
     }
 
@@ -154,8 +155,9 @@ class ActivitiesTable extends Component
      * @param Activity $activity
      * @return void
      */
-    public function openDeleteModal(Activity $activity): void
+    public function openDeleteModal($id): void
     {
+        $activity = Activity::find($id);
         $this->dispatch('open-modal', $activity)->to('sys.activities.activity-delete');
     }
 
@@ -164,8 +166,9 @@ class ActivitiesTable extends Component
      * @param Activity $activity
      * @return void
      */
-    public function open_register_attendance_modal(Activity $activity): void
+    public function open_register_attendance_modal($id): void
     {
+        $activity = Activity::find($id);
         $this->dispatch('open-modal', $activity)->to('sys.activities.register_attendance');
     }
 

--- a/resources/views/livewire/sys/activities/activities-table.blade.php
+++ b/resources/views/livewire/sys/activities/activities-table.blade.php
@@ -234,10 +234,10 @@
     {{-- include wire components --}}
 
     {{-- activity-form --}}
-    <livewire:sys.activities.activity-form wire:key="activity-form-{{ $this->id() }}"/>
+    <livewire:sys.activities.activity-form wire:key="'activity-form'" lazy/>
     {{-- activity-delete --}}
-    <livewire:sys.activities.activity-delete wire:key="activity-delete-{{ $this->id() }}"/>
+    <livewire:sys.activities.activity-delete wire:key="'activity-delete'" lazy/>
     {{-- regiter-attendance --}}
-    <livewire:sys.activities.register-attendance wire:key="register-attendance-{{ $this->id() }}"/>
+    <livewire:sys.activities.register-attendance wire:key="'register-attendance'" lazy/>
 
 </div>


### PR DESCRIPTION
- Updated `openEditModal`, `openDeleteModal`, and `open_register_attendance_modal` methods to accept activity IDs instead of objects for improved performance and clarity.
- Modified Blade view to use static wire:key attributes for Livewire components, enhancing reactivity and reducing unnecessary re-renders.