### PR TITLE
Update Livewire modal binding and add wire:key to location searcher c…

### DIFF
--- a/resources/views/components/sys/activities/form-card.blade.php
+++ b/resources/views/components/sys/activities/form-card.blade.php
@@ -117,6 +117,7 @@
     <x-forms.input-group class="w-full col-span-full">
         {{-- select --}}
         <livewire:sys.locations.searcher
+            wire:key="'location-searcher'"
             label_name="{{ __('messages.models.activity.location') }}"
             :dispatch_references="$location_dispatch_references"
             :custom_list="1"

--- a/resources/views/livewire/sys/activities/activity-form.blade.php
+++ b/resources/views/livewire/sys/activities/activity-form.blade.php
@@ -1,6 +1,6 @@
 <div>
 
-    <x-modals.modal-dialog wire:model='open' includeFooter="0">
+    <x-modals.modal-dialog wire:model.live='open' includeFooter="0">
         <!-- modal title -->
         <x-slot:title>
             <div class="flex flex-row items-center">


### PR DESCRIPTION
…omponent

- Changed modal binding in the activity form from `wire:model` to `wire:model.live` for improved reactivity.
- Added a `wire:key` attribute to the location searcher component to enhance performance and ensure proper reactivity during updates.